### PR TITLE
<doc>: 避免因go编译环境问题导致gohangout在docker容器中运行失败[issue 28]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 
   > make
 
+为避免编译后gohangout在docker容器中无法正常启动，推荐使用完整编译命令进行编译，如：
+
+  > GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make
+
 ### 下载编译后二进制文件
 
 [https://github.com/childe/gohangout/releases](https://github.com/childe/gohangout/releases) 直接下载


### PR DESCRIPTION
编译go代码时，默认`CGO_ENABLED=1`，Go代码中如调用C代码，会进行cgo，对外部有依赖（动态链接），而在Alpine linux这个基础docker镜像下运行可能造成兼容性问题，所以推荐编译时指定`CGO_ENABLED=0`，go采用纯静态编译，编译出来是纯静态的go程序，不会出现外部库依赖问题。

Issue #28
Close #28