### PR TITLE
fix json decode for strong type storage

### DIFF
--- a/codec/json_decoder.go
+++ b/codec/json_decoder.go
@@ -2,6 +2,7 @@ package codec
 
 import (
 	"bytes"
+	stdJson "encoding/json"
 	"time"
 )
 
@@ -18,6 +19,18 @@ func (jd *JsonDecoder) Decode(value []byte) map[string]interface{} {
 		return map[string]interface{}{
 			"@timestamp": time.Now(),
 			"message":    string(value),
+		}
+	}
+
+	for k, v := range rst {
+		if nv, ok := v.(stdJson.Number); ok {
+			if rv, err := nv.Int64(); err == nil {
+				rst[k] = rv
+			} else if rv, err := nv.Float64(); err == nil {
+				rst[k] = rv
+			} else {
+				rst[k] = nv.String
+			}
 		}
 	}
 	return rst

--- a/output/clickhouse_output.go
+++ b/output/clickhouse_output.go
@@ -271,14 +271,14 @@ func NewClickhouseOutput(config map[interface{}]interface{}) *ClickhouseOutput {
 		p.bulk_actions = CLICKHOUSE_DEFAULT_BULK_ACTIONS
 	}
 
-	var flush_interval int
+	var flushInterval int
 	if v, ok := config["flush_interval"]; ok {
-		flush_interval = v.(int)
+		flushInterval = v.(int)
 	} else {
-		flush_interval = CLICKHOUSE_DEFAULT_FLUSH_INTERVAL
+		flushInterval = CLICKHOUSE_DEFAULT_FLUSH_INTERVAL
 	}
 	go func() {
-		for range time.NewTicker(time.Second * time.Duration(flush_interval)).C {
+		for range time.NewTicker(time.Second * time.Duration(flushInterval)).C {
 			p.Flush()
 		}
 	}()


### PR DESCRIPTION
kafka json decode时，int、float64等number类型解码之后，类型都为json.Number，此时clickhouse这类强类型存储解析时无法识别当string处理
![image](https://user-images.githubusercontent.com/6611745/59997003-58273e00-968e-11e9-82d0-f9f69ae9caf2.png)
