### PR TITLE
为ElasticsearchOutPut添加一个es_version的版本控制，可以通过配置指定具体的Elasticsearch版本。

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Elasticsearch:
     flush_interval: 60
     concurrent: 3
     compress: false
+    es_version: 7
     retry_response_code: [401, 502]
 ```
 
@@ -360,6 +361,10 @@ bulk 的goroutine 最大值, 默认1
 #### compress
 
 默认 true, http请求时做zip压缩
+
+#### es_version
+
+默认为6，可以适配es6的版本，如果设置为7，则可以适配Elasticsearch7以上版本
 
 #### retry_response_code
 

--- a/test/itest-es7.yml
+++ b/test/itest-es7.yml
@@ -1,0 +1,22 @@
+inputs:
+  - Random:
+      from: 1
+      to: 100
+      max_messages: 1000
+outputs:
+  #    - Stdout: {}
+  - Stdout: {}
+  - Elasticsearch:
+      hosts:
+        - 'http://username:password@10.0.0.2:9200'
+      index: 'web-%{+2006.01.02}'
+      index_time_location: 'UTC'
+      index_type: "logs"
+      bulk_actions: 10
+      bulk_size: 5
+      flush_interval: 5
+      concurrent: 1
+      compress: false
+      es_version: 7
+#      es_version: 6
+      retry_response_code: [401, 502]


### PR DESCRIPTION
测试了一下gohangout的Elasticsearch貌似不能将数据写入到Elasticsearch7以上的版本，所以为ElasticsearchOutPut添加一个es_version的版本控制，可以通过配置指定具体的Elasticsearch版本。
具体的做法就是在es_version为7时，不在meta数据中添加_type相关内容。