### PR TITLE
Fix tag

### DIFF
--- a/topology/filter.go
+++ b/topology/filter.go
@@ -82,7 +82,7 @@ func (f *FilterBox) PostProcess(event map[string]interface{}, success bool) map[
 				} else {
 				}
 			} else {
-				event["tags"] = []interface{}{f.failTag}
+				event["tags"] = f.failTag
 			}
 		}
 	}

--- a/topology/filter.go
+++ b/topology/filter.go
@@ -76,13 +76,13 @@ func (f *FilterBox) PostProcess(event map[string]interface{}, success bool) map[
 		if f.failTag != "" {
 			if tags, ok := event["tags"]; ok {
 				if reflect.TypeOf(tags).Kind() == reflect.String {
-					event["tags"] = []string{tags.(string), f.failTag}
+					event["tags"] = []interface{}{tags.(string), f.failTag}
 				} else if reflect.TypeOf(tags).Kind() == reflect.Array {
 					event["tags"] = append(tags.([]interface{}), f.failTag)
 				} else {
 				}
 			} else {
-				event["tags"] = f.failTag
+				event["tags"] = []interface{}{f.failTag}
 			}
 		}
 	}


### PR DESCRIPTION
[fix]修复tag相关问题：
1、grok失败时，添加标签时tags类型为string，应当为[]interface{}类型
2、当原先日志中有tags时，并且tags为string类型，应当将tags变为[]interface{}类型，否则使用IN判断时会失败