### PR TITLE
refactor: replace exit chan with context

### DIFF
--- a/gohangout.go
+++ b/gohangout.go
@@ -84,7 +84,7 @@ func init() {
 
 	flag.StringVar(&options.prometheus, "prometheus", "", "address to expose prometheus metrics")
 
-	flag.BoolVar(&options.exitWhenNil, "exit-when-nil", true, "triger gohangout to exit when receive a nil event")
+	flag.BoolVar(&options.exitWhenNil, "exit-when-nil", false, "triger gohangout to exit when receive a nil event")
 
 	flag.Parse()
 }

--- a/input/input_box.go
+++ b/input/input_box.go
@@ -24,7 +24,7 @@ type InputBox struct {
 	promCounter prometheus.Counter
 
 	shutdownWhenNil    bool
-	mainThreadExitChan chan struct{}
+	exit 						   func()
 
 	addFields map[field_setter.FieldSetter]value_render.ValueRender
 }
@@ -35,7 +35,7 @@ func (box *InputBox) SetShutdownWhenNil(shutdownWhenNil bool) {
 	box.shutdownWhenNil = shutdownWhenNil
 }
 
-func NewInputBox(input topology.Input, inputConfig map[interface{}]interface{}, config map[string]interface{}, mainThreadExitChan chan struct{}) *InputBox {
+func NewInputBox(input topology.Input, inputConfig map[interface{}]interface{}, config map[string]interface{}, exit func()) *InputBox {
 	b := &InputBox{
 		input:        input,
 		config:       config,
@@ -44,7 +44,7 @@ func NewInputBox(input topology.Input, inputConfig map[interface{}]interface{}, 
 
 		promCounter: topology.GetPromCounter(inputConfig),
 
-		mainThreadExitChan: mainThreadExitChan,
+		exit:        exit,
 	}
 	if add_fields, ok := inputConfig["add_fields"]; ok {
 		b.addFields = make(map[field_setter.FieldSetter]value_render.ValueRender)
@@ -81,7 +81,7 @@ func (box *InputBox) beat(workerIdx int) {
 			}
 			if box.shutdownWhenNil {
 				glog.Info("received nil message. shutdown...")
-				box.mainThreadExitChan <- struct{}{}
+			  box.exit()
 				break
 			} else {
 				continue


### PR DESCRIPTION
I saw your `TODO` mark. Would it be better to use `context`?  @childe 