### PR TITLE
add: date filter support ISO8601

### DIFF
--- a/filter/date_test.go
+++ b/filter/date_test.go
@@ -74,6 +74,32 @@ func TestFormatParserWithLocation(t *testing.T) {
 	}
 }
 
+func TestISO8601Parser(t *testing.T) {
+    var tArr = [5]string{
+        "2020-01-28T19:52:12",
+        "2020-01-28T19:52:12.000",
+        "2020-01-28T11:52:12Z",
+        "2020-01-28T19:52:12+0800",
+        "2020-01-28T19:52:12+08:00",
+    }
+    // further cases please see: https://github.com/relvacode/iso8601/blob/master/iso8601_test.go
+
+    location, _ := time.LoadLocation("Asia/Shanghai")
+	p := &ISO8601Parser{location}
+	for _, tStr := range tArr {
+	    r, err := p.Parse(tStr)
+
+    	if err != nil {
+    		t.Fatalf("%s", err)
+    	}
+
+    	rr := r.UnixNano() / 1000
+    	if rr != ts * 1000000 {
+    		t.Fatalf("%v %d", tStr, rr)
+    	}
+	}
+}
+
 func TestDateFilter(t *testing.T) {
 	config := make(map[interface{}]interface{})
 	config["location"] = "Asia/Shanghai"

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/prometheus/client_golang v1.12.1
+	github.com/relvacode/iso8601 v1.6.0
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0
 	go.uber.org/automaxprocs v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/relvacode/iso8601 v1.6.0 h1:eFXUhMJN3Gz8Rcq82f9DTMW0svjtAVuIEULglM7QHTU=
+github.com/relvacode/iso8601 v1.6.0/go.mod h1:FlNp+jz+TXpyRqgmM7tnzHHzBnz776kmAH2h3sZCn0I=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=


### PR DESCRIPTION
add: date filter support ISO8601

use pkg: github.com/relvacode/iso8601

最近在进行 logstash 与 gohangout 互转的实现，业务场景中用到 logstash date filter 时，使用 ISO8601 format 的频率较高。本想通过列出所有 ISO8601 的支持 format 实现，但是过于冗长。最终找了一个包进行二次开发支持，大佬看下有无必要合进去。

_注明：这个包不支持 week 相关、day of year、省略某些值等等较为不常用的写法。_